### PR TITLE
Return all entries when using empty query and invert option.

### DIFF
--- a/src/pocof/Query.fs
+++ b/src/pocof/Query.fs
@@ -122,7 +122,8 @@ module PocofQuery =
             <| q
 
         let answer =
-            if state.QueryState.Invert then
+            if (String.IsNullOrWhiteSpace >> not) state.Query
+               && state.QueryState.Invert then
                 not
             else
                 id

--- a/tests/pocof.Tests.ps1
+++ b/tests/pocof.Tests.ps1
@@ -34,7 +34,9 @@ Describe 'pocof' {
             @{ Matcher = 'EQ' }
         ) {
             It "Given a '<InputObject>', '<Expected>' should be returned." -TestCases @(
-                @{Expected = 'Hello,world' ; Params = @{Query = '' } + $BaseParam + $_ }
+                @{Expected = 'Hello,world'; Params = $BaseParam + $_ }
+                @{Expected = 'Hello,world'; Params = @{InvertQuery = $true } + $BaseParam + $_ }
+                @{Expected = 'Hello,world'; Params = @{CaseSensitive = $true } + $BaseParam + $_ }
             ) {
                 $InputObject | Select-Pocof @Params | Should -BeExactly -ExpectedValue $Expected
             }


### PR DESCRIPTION
Fix #23 