### PR TITLE
Set rendering to be required when the cursor is changed by the invocation of the beginning or end of a line.

### DIFF
--- a/src/pocof.Test/PocofHandle.fs
+++ b/src/pocof.Test/PocofHandle.fs
@@ -174,7 +174,7 @@ module invokeAction =
             let state =
                 { state with
                     Query = ":name"
-                    PropertySearch = Search "name" }
+                    PropertySearch = NoSearch }
 
             let state, context = PocofQuery.prepare state
             let a1, a2, a3 = invokeAction state { X = 0; Y = 0 } context BeginningOfLine

--- a/src/pocof.Test/PocofHandle.fs
+++ b/src/pocof.Test/PocofHandle.fs
@@ -157,7 +157,6 @@ module invokeAction =
                     PropertySearch = Search "name" }
 
             let state, context = PocofQuery.prepare state
-
             let a1, a2, a3 = invokeAction state { X = 5; Y = 0 } context BeginningOfLine
 
             (a1, a2)
@@ -178,7 +177,6 @@ module invokeAction =
                     PropertySearch = Search "name" }
 
             let state, context = PocofQuery.prepare state
-
             let a1, a2, a3 = invokeAction state { X = 0; Y = 0 } context BeginningOfLine
 
             (a1, a2)
@@ -192,40 +190,16 @@ module invokeAction =
 
             a3.Queries |> shouldEqual []
 
-        [<Fact>]
-        let ``should return no change with pos modified when NonSearch`` () =
-            let state =
-                { state with
-                    Query = "query"
-                    PropertySearch = NoSearch }
-
-            let state, context = PocofQuery.prepare state
-
-            let a1, a2, a3 = invokeAction state { X = 5; Y = 0 } context BeginningOfLine
-
-            (a1, a2)
-            |> (shouldEqual (
-                { state with
-                    Query = "query"
-                    PropertySearch = NoSearch
-                    Refresh = NotRequired },
-                { X = 0; Y = 0 }
-            ))
-
-            a3.Queries
-            |> shouldEqual [ PocofQuery.Normal("query") ]
-
     module ``with EndOfLine`` =
         [<Fact>]
         let ``should return state with position.X = query length.`` () =
             let state =
                 { state with
                     Query = ":name"
-                    PropertySearch = Search "n" }
+                    PropertySearch = NoSearch }
 
             let state, context = PocofQuery.prepare state
-
-            let a1, a2, a3 = invokeAction state { X = 2; Y = 0 } context EndOfLine
+            let a1, a2, a3 = invokeAction state { X = 0; Y = 0 } context EndOfLine
 
             (a1, a2)
             |> shouldEqual (
@@ -246,7 +220,6 @@ module invokeAction =
                     PropertySearch = Search "name" }
 
             let state, context = PocofQuery.prepare state
-
             let a1, a2, a3 = invokeAction state { X = 5; Y = 0 } context EndOfLine
 
             (a1, a2)
@@ -259,29 +232,6 @@ module invokeAction =
             )
 
             a3.Queries |> shouldEqual []
-
-        [<Fact>]
-        let ``should return no change with pos modified when NonSearch`` () =
-            let state =
-                { state with
-                    Query = "query"
-                    PropertySearch = NoSearch }
-
-            let state, context = PocofQuery.prepare state
-
-            let a1, a2, a3 = invokeAction state { X = 0; Y = 0 } context EndOfLine
-
-            (a1, a2)
-            |> shouldEqual (
-                { state with
-                    Query = "query"
-                    PropertySearch = NoSearch
-                    Refresh = NotRequired },
-                { X = 5; Y = 0 }
-            )
-
-            a3.Queries
-            |> shouldEqual [ PocofQuery.Normal("query") ]
 
     module ``with DeleteBackwardChar`` =
         [<Fact>]

--- a/src/pocof/Handle.fs
+++ b/src/pocof/Handle.fs
@@ -47,21 +47,14 @@ module PocofHandle =
     let private moveHead (state: InternalState) (pos: Position) (context: QueryContext) =
         { state with
             PropertySearch = NoSearch
-            Refresh =
-                (pos.X <> 0 && state.PropertySearch <> NoSearch)
-                |> Refresh.ofBool },
+            Refresh = pos.X <> 0 |> Refresh.ofBool },
         { pos with X = 0 },
         context
 
     let private moveTail (state: InternalState) (pos: Position) (context: QueryContext) =
-        let ps = getCurrentProperty state.Query state.Query.Length
-
         { state with
             PropertySearch = getCurrentProperty state.Query state.Query.Length
-            Refresh =
-                (pos.X <> state.Query.Length
-                 && ps <> state.PropertySearch)
-                |> Refresh.ofBool },
+            Refresh = pos.X <> state.Query.Length |> Refresh.ofBool },
         { pos with X = state.Query.Length },
         context
 


### PR DESCRIPTION
fix #106