### PR TITLE
Bump xunit to 2.7.0.

### DIFF
--- a/src/pocof.Test/pocof.Test.fsproj
+++ b/src/pocof.Test/pocof.Test.fsproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="FsUnit.xUnit" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit" Version="2.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
xUnit 2.7.0 is missing from PR #142 and #143.