### PR TITLE
Correct the displayed operators from `notcmatch` and `notclike` to `cnotmatch` and `cnotlike`

### DIFF
--- a/src/pocof.Test/Data.fs
+++ b/src/pocof.Test/Data.fs
@@ -127,16 +127,16 @@ module ``QueryState toString should returns`` =
         string actual |> shouldEqual "notlike and"
 
     [<Fact>]
-    let ``notclike and`` () =
+    let ``cnotlike and`` () =
         let actual = queryState Matcher.Like Operator.And |> caseSensitive |> invert
 
-        string actual |> shouldEqual "notclike and"
+        string actual |> shouldEqual "cnotlike and"
 
     [<Fact>]
-    let ``notcmatch or`` () =
+    let ``cnotmatch or`` () =
         let actual = queryState Matcher.Match Operator.Or |> caseSensitive |> invert
 
-        string actual |> shouldEqual "notcmatch or"
+        string actual |> shouldEqual "cnotmatch or"
 
     [<Fact>]
     let ``notmatch or`` () =
@@ -180,7 +180,7 @@ module initConfig =
                 { Query = ":name"
                   Cursor = 5
                   WindowBeginningCursor = 0
-                  WindowWidth = 60 - (String.length "prompt>") - (String.length " notclike and [10]")
+                  WindowWidth = 60 - (String.length "prompt>") - (String.length " cnotlike and [10]")
                   InputMode = InputMode.Input }
               QueryCondition =
                 { Matcher = Matcher.Like

--- a/src/pocof/Data.fs
+++ b/src/pocof/Data.fs
@@ -305,15 +305,16 @@ module Data =
           Invert: bool }
 
         override __.ToString() =
-            List.append
-            <| match __.Matcher, __.CaseSensitive, __.Invert with
-               | m, false, false -> [ string m ]
-               | m, true, false -> [ "c"; string m ]
-               | Matcher.Eq, false, true -> [ "ne" ]
-               | Matcher.Eq, true, true -> [ "cne" ]
-               | m, false, true -> [ "not"; string m ]
-               | m, true, true -> [ "cnot"; string m ]
-            <| [ " "; string __.Operator ]
+            [ match __.CaseSensitive with
+              | true -> "c"
+              | _ -> ""
+              // NOTE: use ToString to avoid extra branches when calculating coverages.
+              match __.Matcher, __.Invert with
+              | Matcher.Eq, true -> "ne"
+              | m, true -> "not" + m.ToString()
+              | m, _ -> m.ToString()
+              " "
+              __.Operator.ToString() ]
             |> String.concat ""
 
     module QueryCondition =

--- a/src/pocof/Data.fs
+++ b/src/pocof/Data.fs
@@ -312,7 +312,7 @@ module Data =
                | Matcher.Eq, false, true -> [ "ne" ]
                | Matcher.Eq, true, true -> [ "cne" ]
                | m, false, true -> [ "not"; string m ]
-               | m, true, true -> [ "notc"; string m ]
+               | m, true, true -> [ "cnot"; string m ]
             <| [ " "; string __.Operator ]
             |> String.concat ""
 


### PR DESCRIPTION
Fix #155