### PR TITLE
Update `dotnet test` command to include blame hang timeout.

### DIFF
--- a/psakefile.ps1
+++ b/psakefile.ps1
@@ -63,7 +63,7 @@ Task Build -depends Clean {
 
 Task UnitTest {
     Remove-Item ./src/pocof.Test/TestResults/* -Recurse -ErrorAction SilentlyContinue
-    dotnet test --collect:"XPlat Code Coverage" --nologo --logger:"console;verbosity=detailed"
+    dotnet test --collect:"XPlat Code Coverage" --nologo --logger:"console;verbosity=detailed" --blame-hang-timeout 3s --blame-hang-dump-type full
     if (-not $?) {
         throw 'dotnet test failed.'
     }


### PR DESCRIPTION
resolve #227