### PR TITLE
Refactor the `Receive` method to handle an empty render stack gracefully for .NET Framework forward compatibility.

### DIFF
--- a/src/pocof/Pocof.fs
+++ b/src/pocof/Pocof.fs
@@ -209,6 +209,8 @@ module Pocof =
         member __.Receive() =
             renderStack.Count
             |> function
+                // NOTE: case of 0 is required for .NET Framework forward compatibility.
+                // NOTE: .NET does not raise an error, but it does not match the documentation.
                 | 0 -> RenderMessage.None
                 | c ->
                     let items = Array.zeroCreate<RenderEvent> c

--- a/src/pocof/Pocof.fs
+++ b/src/pocof/Pocof.fs
@@ -207,9 +207,13 @@ module Pocof =
         member __.Publish = renderStack.Push
 
         member __.Receive() =
-            let items = Array.zeroCreate<RenderEvent> renderStack.Count
-            renderStack.TryPopRange(items) |> ignore
-            items |> Array.toList |> getLatestEvent
+            renderStack.Count
+            |> function
+                | 0 -> RenderMessage.None
+                | c ->
+                    let items = Array.zeroCreate<RenderEvent> c
+                    renderStack.TryPopRange(items) |> ignore
+                    items |> Array.toList |> getLatestEvent
 
     [<TailCall>]
     let rec render (buff: Screen.Buff) (handler: RenderHandler) (conf: InternalConfig) =

--- a/src/pocof/Pocof.fs
+++ b/src/pocof/Pocof.fs
@@ -207,15 +207,17 @@ module Pocof =
         member __.Publish = renderStack.Push
 
         member __.Receive() =
-            renderStack.Count
-            |> function
+            let items =
+                match renderStack.Count with
                 // NOTE: case of 0 is required for .NET Framework forward compatibility.
                 // NOTE: .NET does not raise an error, but it does not match the documentation.
-                | 0 -> RenderMessage.None
+                | 0 -> []
                 | c ->
                     let items = Array.zeroCreate<RenderEvent> c
                     renderStack.TryPopRange(items) |> ignore
-                    items |> Array.toList |> getLatestEvent
+                    items |> Array.toList
+
+            items |> getLatestEvent
 
     [<TailCall>]
     let rec render (buff: Screen.Buff) (handler: RenderHandler) (conf: InternalConfig) =


### PR DESCRIPTION
fix #235