### PR TITLE
Suppress error when accessing Linux-dependent properties.

### DIFF
--- a/src/pocof.Test/Data.fs
+++ b/src/pocof.Test/Data.fs
@@ -33,6 +33,27 @@ module LanguageExtension =
             // NOTE: only for coverage.
             None |> Option.dispose
 
+    module Entry =
+        open System.Management.Automation
+
+        type MockProperty() =
+            // NOTE: use a custom property inherited AdaptedProperty to call Value getter for PSObject.
+            inherit PSAdaptedProperty("Dummy", "dummy")
+
+            override __.Value
+                with get () = failwith "MockProperty.Value raises error."
+                and set (_) = ()
+
+        [<Fact>]
+        let ``shouldn't fail when accessing error-prone properties and should return None`` () =
+            // NOTE: only for coverage.
+            let a = PSObject.AsPSObject("a")
+            let p = MockProperty()
+            // NOTE: requires passing true to preValidated to skip the check for CannotAddPropertyOrMethod.
+            // https://github.com/PowerShell/PowerShell/blob/c505f4ba39111df8bd8a957f8632ff9697639f0b/src/System.Management.Automation/engine/MshMemberInfo.cs#L4598C29-L4598C30
+            a.Properties.Add(p, true)
+            a["Dummy"] |> shouldEqual None
+
 module unwrap =
     open System.Collections
     open System.Management.Automation

--- a/src/pocof/Data.fs
+++ b/src/pocof/Data.fs
@@ -122,7 +122,13 @@ module LanguageExtension =
                 __.Properties[prop]
                 |> function
                     | null -> null
-                    | p -> p.Value
+                    | p ->
+                        try
+                            p.Value
+                        with _ ->
+                            // TODO: error occurs on Linux when accessing Linux-dependent properties. currently, suppress the error.
+                            // Exception getting "Size": "There is no Runspace available to run scripts in this thread. You can provide one in the DefaultRunspace property of the System.Management.Automation.Runspaces.Runspace type. The script block you attempted to invoke was: $this.UnixStat.Size"
+                            null
 
 module Data =
     open System

--- a/tests/pocof.Tests.ps1
+++ b/tests/pocof.Tests.ps1
@@ -328,4 +328,13 @@ Describe 'pocof' {
             }
         }
     }
+
+    if ($PSVersionTable.Platform -eq 'Unix') {
+        Context 'Select-Pocof cmdlet with Unix' {
+            It "shouldn't raise error when accessing platform-dependent properties." {
+                { Get-ChildItem | Select-Pocof ':User a' -NonInteractive } | Should -Not -Throw '*'
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
resolve #317

This is a temporary fix.